### PR TITLE
Spark backend for large scale controlled parallelism and caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,105 +1,119 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>edu.usc.irds.ml</groupId>
-  <artifactId>svm-classifier</artifactId>
-  <version>1.2-SNAPSHOT</version>
-  <packaging>jar</packaging>
+    <groupId>edu.usc.irds.ml</groupId>
+    <artifactId>svm-classifier</artifactId>
+    <version>1.2-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-  <name>svm-classifier</name>
-  <url>http://maven.apache.org</url>
+    <name>svm-classifier</name>
+    <url>http://maven.apache.org</url>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <exec.mainClass>edu.usc.irds.ml.svm.SVMCli</exec.mainClass>
-  </properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <exec.mainClass>edu.usc.irds.ml.svm.SVMCli</exec.mainClass>
+    </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>tw.edu.ntu.csie</groupId>
-      <artifactId>libsvm</artifactId>
-      <version>3.17</version>
-    </dependency>
+    <dependencies>
+        <dependency>
+            <groupId>tw.edu.ntu.csie</groupId>
+            <artifactId>libsvm</artifactId>
+            <version>3.17</version>
+        </dependency>
 
-    <dependency>
-      <groupId>args4j</groupId>
-      <artifactId>args4j</artifactId>
-      <version>2.0.29</version>
-    </dependency>
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+            <version>2.0.29</version>
+        </dependency>
 
-    <!-- https://mvnrepository.com/artifact/edu.stanford.nlp/stanford-corenlp -->
-    <dependency>
-      <groupId>edu.stanford.nlp</groupId>
-      <artifactId>stanford-corenlp</artifactId>
-      <version>3.6.0</version>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/edu.stanford.nlp/stanford-corenlp -->
-    <dependency>
-      <groupId>edu.stanford.nlp</groupId>
-      <artifactId>stanford-corenlp</artifactId>
-      <version>3.6.0</version>
-      <classifier>models</classifier>
-    </dependency>
+        <!-- https://mvnrepository.com/artifact/edu.stanford.nlp/stanford-corenlp -->
+        <dependency>
+            <groupId>edu.stanford.nlp</groupId>
+            <artifactId>stanford-corenlp</artifactId>
+            <version>3.6.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/edu.stanford.nlp/stanford-corenlp -->
+        <dependency>
+            <groupId>edu.stanford.nlp</groupId>
+            <artifactId>stanford-corenlp</artifactId>
+            <version>3.6.0</version>
+            <classifier>models</classifier>
+        </dependency>
 
 
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20140107</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.12</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.12</version>
-    </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20140107</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.12</version>
+        </dependency>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-        <!-- Maven Assembly Plugin -->
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <configuration>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-                <archive>
-                    <manifest>
-                        <mainClass>${exec.mainClass}</mainClass>
-                    </manifest>
-                </archive>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.12</version>
+        </dependency>
 
-            </configuration>
-            <executions>
-                <execution>
-                    <id>make-assembly</id>
-                    <phase>package</phase>
-                    <goals>
-                        <goal>single</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-    </plugins>
-  </build>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.11</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <!-- Maven Assembly Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>${exec.mainClass}</mainClass>
+                        </manifest>
+                    </archive>
+
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/edu/usc/irds/ml/svm/ComputeBackend.java
+++ b/src/main/java/edu/usc/irds/ml/svm/ComputeBackend.java
@@ -1,0 +1,13 @@
+package edu.usc.irds.ml.svm;
+
+
+import java.io.File;
+import java.io.IOException;
+
+public interface ComputeBackend {
+
+    Dictionary makeDictionary(File input, File output) throws IOException;
+    void vectorize(File input, File vector, File dictionary) throws IOException;
+    void shutdown();
+
+}

--- a/src/main/java/edu/usc/irds/ml/svm/ConcurrentRunner.java
+++ b/src/main/java/edu/usc/irds/ml/svm/ConcurrentRunner.java
@@ -1,0 +1,203 @@
+package edu.usc.irds.ml.svm;
+
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ */
+public class ConcurrentRunner implements ComputeBackend {
+
+    private static Logger LOG = LoggerFactory.getLogger(ConcurrentRunner.class);
+
+    private int nThreads = SVMCli.Constants.NUM_THREADS;
+    private NlpPipeline pipeline = new NlpPipeline();
+
+    private ThreadPoolExecutor pool = new ThreadPoolExecutor(nThreads, nThreads, 5, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(nThreads * 20));
+
+    public TreeMap<Integer, Double> vectorize(String text, Dictionary dict){
+        Collection<String> tokens = pipeline.getTokens(text, false);
+        TreeMap<Integer, Double> result = new TreeMap<>();
+        tokens.forEach(token -> {
+            Integer number = dict.reverseLookup(token);
+            if (number != null) {
+                result.put(number, 1.0 + result.getOrDefault(number, 0.0));
+            }
+        });
+        return result;
+    }
+
+    public static Stream<String> getTextStream(File... inputs) throws IOException {
+        SVMCli.LOG.info("Reading data from {}", Arrays.toString(inputs));
+        Stream<String> content = new ArrayList<String>().stream();
+        for (File input : inputs) {
+            content = Stream.concat(content, Files.lines(input.toPath()));
+        }
+        return content;
+    }
+
+    public Dictionary makeDictionary(File inputs, File dictionaryFile) throws IOException {
+
+        //getting featured text out of documents
+        Iterator<String> source = getTextStream(inputs).map(Utils::getFeaturedText).iterator();
+        Function<String, Collection<String>> tokenizer = s -> pipeline.getTokens(s, true);
+
+        Dictionary dict = build(source, tokenizer, nThreads, SVMCli.Constants.VOCABULARY_SIZE);
+
+        try (FileOutputStream stream = new FileOutputStream(dictionaryFile)) {
+            SVMCli.LOG.info("Storing the dictionary at {}", dictionaryFile);
+            dict.save(stream);
+        }
+
+        return dict;
+    }
+
+    public Dictionary build(Iterator<String> source,
+                                   Function<String, Collection<String>> tokenizer, int nThreads, int nTokens){
+        LOG.info("Building dictionary, Threads={}, tokens={}", nThreads, nTokens);
+        Set<String> words = new HashSet<>();
+        AtomicBoolean completed = new AtomicBoolean(false);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.println("Terminating.....");
+            if (!completed.get()){
+                List<String> list = new ArrayList<>(words);
+                try {
+                    System.out.println("Writing tmp dictionary");
+                    try (FileOutputStream stream = new FileOutputStream(".tmp-dictionary.txt");) {
+                        new Dictionary(list).save(stream);
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }));
+        long count = 0;
+        long st = System.currentTimeMillis();
+        long delay = 2000;
+        while (source.hasNext()){
+            count++;
+            Runnable task = () -> words.addAll(tokenizer.apply(source.next()));
+            try {
+                pool.submit(task);
+            } catch (RejectedExecutionException e){
+                while (pool.getQueue().size() > 2 * nThreads) {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e1) {
+                        e1.printStackTrace();
+                    }
+                }
+                pool.submit(task);
+            }
+            if (System.currentTimeMillis() - st > delay){
+                st = System.currentTimeMillis();
+                LOG.info("Input = {}, Tokens={}, active threads={}, queued tasks={}", count, words.size(),
+                        pool.getActiveCount(), pool.getQueue().size());
+            }
+            if (words.size() > nTokens) {
+                LOG.warn("Got {} tokens, breaking the loop and skipping the rest of input", words.size());
+                break;
+            }
+        }
+        List<String> list = new ArrayList<>(words);
+        completed.set(true);
+        return new Dictionary(list);
+    }
+
+    public void vectorize(File input, File vectorFile, File dictionaryFile) throws IOException {
+        SVMCli.LOG.info("Vectorizing....");
+        Dictionary dictionary;
+        try (InputStream inputStream = new FileInputStream(dictionaryFile)) {
+            SVMCli.LOG.info("Dictionary : {}", dictionaryFile);
+            dictionary = Dictionary.load(inputStream);
+        }
+        Map<String, Doc> clusters = new ConcurrentHashMap<>();
+        Map<String, Integer> clusterSize = new HashMap<>();
+
+        final AtomicLong counter = new AtomicLong();
+        final AtomicLong st = new AtomicLong(System.currentTimeMillis());
+        final int nThreads = SVMCli.Constants.NUM_THREADS;
+        final long delay = 2000;
+
+        getTextStream(input).forEach(line -> {
+            Runnable task = () -> {
+                counter.incrementAndGet();
+                JSONObject j = new JSONObject(line);
+                Doc d = new Doc(j.getString("cluster_id"), vectorize(Utils.getFeaturedText(j), dictionary),
+                        j.optInt("class", Doc.NO_LABEL));
+                if (clusters.containsKey(d.id)) {
+                    //clusters.get(d.id).merge(d);
+                    clusters.get(d.id).mergeMax(d);
+                } else {
+                    clusters.put(d.id, d);
+                }
+                clusterSize.put(d.id, 1 + clusterSize.getOrDefault(d.id, 0));
+            };
+
+            try {
+                pool.submit(task);
+            } catch (RejectedExecutionException e) {
+                while (pool.getQueue().size() > 2 * nThreads) {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e1) {
+                        e1.printStackTrace();
+                    }
+                }
+                pool.submit(task);
+            }
+            if (System.currentTimeMillis() - st.get() > delay) {
+                st.set(System.currentTimeMillis());
+                SVMCli.LOG.info("Input = {}, Clusters={}, active threads={}, queued tasks={}", counter, clusters.size(),
+                        pool.getActiveCount(), pool.getQueue().size());
+            }
+        });
+
+        SVMCli.LOG.warn("Shutting down the pool");
+        try {
+            pool.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        //TODO: Normalize vector magnitudes to average on the cluster size
+        try (Writer writer = new FileWriter(vectorFile)) {
+            clusters.values().forEach(d -> d.writeSvmLiteVector(writer));
+        }
+        SVMCli.LOG.info("Wrote {} vectors to {}", clusters.size(), vectorFile);
+    }
+
+    public void shutdown(){
+        pool.shutdown();
+    }
+
+}

--- a/src/main/java/edu/usc/irds/ml/svm/Dictionary.java
+++ b/src/main/java/edu/usc/irds/ml/svm/Dictionary.java
@@ -5,35 +5,24 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 /**
  * Dictionary for mapping tokens to numbers and vice versa
  * @author Thamme Gowda
  *
  */
-public class Dictionary {
+public class Dictionary implements Serializable {
 
-    public static final Logger LOG = LoggerFactory.getLogger(Dictionary.class);
     private List<String> map = new ArrayList<>(); //index to string mapper ; efficient than Map<Integer, String>
     private Map<String, Integer> reverseMap = new HashMap<>();
 
@@ -53,67 +42,20 @@ public class Dictionary {
         return reverseMap.get(word);
     }
 
-    public static Dictionary build(Iterator<String> source,
-                                   Function<String, Collection<String>> tokenizer, int nThreads, int nTokens){
-        LOG.info("Building dictionary, Threads={}, tokens={}", nThreads, nTokens);
-        Set<String> words = new HashSet<>();
-        AtomicBoolean completed = new AtomicBoolean(false);
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            System.out.println("Terminating.....");
-            if (!completed.get()){
-                List<String> list = new ArrayList<>(words);
-                try {
-                    System.out.println("Writing tmp dictionary");
-                    try (FileOutputStream stream = new FileOutputStream(".tmp-dictionary.txt");) {
-                        new Dictionary(list).save(stream);
-                    }
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }));
-        long count = 0;
-        long st = System.currentTimeMillis();
-        long delay = 2000;
-        ThreadPoolExecutor pool = new ThreadPoolExecutor(nThreads, nThreads,
-                5, TimeUnit.MILLISECONDS,
-                new ArrayBlockingQueue<>(nThreads * 20));
-        while (source.hasNext()){
-            count++;
-            Runnable task = () -> words.addAll(tokenizer.apply(source.next()));
-            try {
-                pool.submit(task);
-            } catch (RejectedExecutionException e){
-                while (pool.getQueue().size() > 2 * nThreads) {
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e1) {
-                        e1.printStackTrace();
-                    }
-                }
-                pool.submit(task);
-            }
-            if (System.currentTimeMillis() - st > delay){
-                st = System.currentTimeMillis();
-                LOG.info("Input = {}, Tokens={}, active threads={}, queued tasks={}", count, words.size(),
-                        pool.getActiveCount(), pool.getQueue().size());
-            }
-            if (words.size() > nTokens) {
-                LOG.warn("Got {} tokens, breaking the loop and skipping the rest of input", words.size());
-                break;
-            }
-        }
-        pool.shutdown();
-        List<String> list = new ArrayList<>(words);
-        completed.set(true);
-        return new Dictionary(list);
+    public int getSize(){
+        return map.size();
     }
+
 
     public void save(OutputStream stream) throws IOException {
         assert map.size() == reverseMap.size();
+        writeLines(stream, map);
+    }
+
+    public static void writeLines(OutputStream stream, List<String> lines) throws IOException {
         try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(stream))){
-            for (int i = 0; i < map.size(); i++) {
-                writer.write(map.get(i));
+            for (String line : lines) {
+                writer.write(line);
                 writer.write('\n');
             }
         }

--- a/src/main/java/edu/usc/irds/ml/svm/Doc.java
+++ b/src/main/java/edu/usc/irds/ml/svm/Doc.java
@@ -1,0 +1,69 @@
+package edu.usc.irds.ml.svm;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.Writer;
+import java.util.SortedMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+public class Doc implements Serializable {
+    public static int NO_LABEL = Integer.MIN_VALUE;
+    public String id;
+    public int label;
+    public SortedMap<Integer, Double> vector;
+
+    public AtomicInteger count = new AtomicInteger(1); // number of child documents, when this one is a result of merge
+
+    public Doc(String id, SortedMap<Integer, Double> vector) {
+        this(id, vector, NO_LABEL);
+    }
+
+    public Doc(String id, SortedMap<Integer, Double> vector, int label) {
+        this.id = id;
+        this.label = label;
+        this.vector = vector;
+    }
+
+    /**
+     * Merges given doc/vector with this doc/vector by adding the magnitudes
+     *
+     * @param doc document which should be merged
+     */
+    public void merge(Doc doc) {
+        assert id.equals(doc.id);
+        assert label == doc.label;
+        synchronized (this) {
+            doc.vector.forEach((k, v) -> this.vector.put(k, this.vector.getOrDefault(k, 0.0) + v));
+        }
+    }
+
+    /**
+     * Merges the documents by keeping the maximum of dimension
+     *
+     * @param doc the doc to be merged
+     */
+    public void mergeMax(Doc doc) {
+        assert id.equals(doc.id);
+        assert label == doc.label;
+        synchronized (this) {
+            doc.vector.forEach((k, v) -> this.vector.put(k, Math.max(this.vector.getOrDefault(k, 0.0), v)));
+        }
+    }
+
+    public void writeSvmLiteVector(Writer writer) {
+        try {
+            writer.write(this.label == NO_LABEL ? this.id : this.label + "");
+            this.vector.forEach((k, v) -> {
+                try {
+                    writer.write(" " + k + ":" + v);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/edu/usc/irds/ml/svm/SVMCli.java
+++ b/src/main/java/edu/usc/irds/ml/svm/SVMCli.java
@@ -3,7 +3,6 @@ package edu.usc.irds.ml.svm;
 import libsvm.svm;
 import libsvm.svm_model;
 import libsvm.svm_node;
-import org.json.JSONObject;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
@@ -12,35 +11,16 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Writer;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.SortedMap;
 import java.util.StringTokenizer;
-import java.util.TreeMap;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static edu.usc.irds.ml.svm.SVMCli.Holder.pipeline;
 
 /**
  *
@@ -50,29 +30,16 @@ public class SVMCli {
 
     public static final Logger LOG = LoggerFactory.getLogger(SVMCli.class);
 
-    public interface Holder {
-        //Lazy loading
-        NlpPipeline pipeline = new NlpPipeline();
-    }
 
-    public static final BiFunction<String, Dictionary, SortedMap<Integer, Double>> vectorizer = (text, dict) -> {
-        Collection<String> tokens = pipeline.getTokens(text, false);
-        TreeMap<Integer, Double> result = new TreeMap<>();
-        tokens.forEach(token -> {
-            Integer number = dict.reverseLookup(token);
-            if (number != null) {
-                result.put(number, 1.0 + result.getOrDefault(number, 0.0));
-            }
-        });
-        return result;
-    };
-
-    interface Constants {
-        String BUILD_DICT = "build-dict";
-        String VECTORIZE = "vectorize";
-        String PREDICT = "predict";
-        int NUM_THREADS = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
-        int VOCABULARY_SIZE = Integer.MAX_VALUE;
+    public static abstract class Constants {
+        public static final String BUILD_DICT = "build-dict";
+        public static final String VECTORIZE = "vectorize";
+        public static final String PREDICT = "predict";
+        public static final String SPARK = "spark";
+        public static final String THREADS = "threads";
+        public static int NUM_THREADS = Math.max(1,
+                Runtime.getRuntime().availableProcessors() - 2);
+        public static final int VOCABULARY_SIZE = Integer.MAX_VALUE;
     }
 
     @Option(name = "-task", required = true, usage = "Task name. example : " + Constants.BUILD_DICT + ", "
@@ -80,7 +47,7 @@ public class SVMCli {
     public List<String> tasknames;
 
     @Option(name = "-input", usage = "Input file to the task")
-    public List<File> inputFiles;
+    public File inputFiles;
 
     @Option(name = "-dict", usage = "path of Dictionary File")
     public File dictionaryFile;
@@ -98,151 +65,11 @@ public class SVMCli {
             usage = "set this flag to generalize the model. Eg: replace proper names with their entity types")
     public boolean generalize = false;
 
-    public static Stream<String> getTextStream(List<File> inputs) throws IOException {
-        LOG.info("Reading data from {}", inputs);
-        Stream<String> content = new ArrayList<String>().stream();
-        for (File input : inputs) {
-            content = Stream.concat(content, Files.lines(input.toPath()));
-        }
-        return content;
-    }
+    @Option(name = "-backend", usage = "Backend to use. example: spark, threads")
+    public String backend = Constants.SPARK;
 
-    public static Dictionary buildDictionary(List<File> inputs, File dictionaryFile) throws IOException {
-
-        //getting featured text out of documents
-        Iterator<String> source = getTextStream(inputs).map(Utils::getFeaturedText).iterator();
-        Function<String, Collection<String>> tokenizer = s -> pipeline.getTokens(s, true);
-
-        Dictionary dict = Dictionary.build(source, tokenizer, Constants.NUM_THREADS, Constants.VOCABULARY_SIZE);
-        try (FileOutputStream stream = new FileOutputStream(dictionaryFile)){
-            LOG.info("Storing the dictionary at {}", dictionaryFile);
-            dict.save(stream);
-        }
-        return dict;
-    }
-
-    public static class Doc {
-        public static int NO_LABEL = Integer.MIN_VALUE;
-        public String id;
-        public int label;
-        public SortedMap<Integer, Double> vector;
-
-        public Doc(String id, SortedMap<Integer, Double> vector) {
-            this(id, vector, NO_LABEL);
-        }
-
-        public Doc(String id, SortedMap<Integer, Double> vector, int label) {
-            this.id = id;
-            this.label = label;
-            this.vector = vector;
-        }
-
-        /**
-         * Merges given doc/vector with this doc/vector by adding the magnitudes
-         * @param doc document which should be merged
-         */
-        public void merge(Doc doc){
-            assert id.equals(doc.id);
-            assert label == doc.label;
-            synchronized (this) {
-                doc.vector.forEach((k, v) -> this.vector.put(k, this.vector.getOrDefault(k, 0.0) + v));
-            }
-        }
-
-        /**
-         * Merges the documents by keeping the maximum of dimension
-         * @param doc the doc to be merged
-         */
-        public void mergeMax(Doc doc){
-            assert id.equals(doc.id);
-            assert label == doc.label;
-            synchronized (this) {
-                doc.vector.forEach((k, v) -> this.vector.put(k, Math.max(this.vector.getOrDefault(k, 0.0), v)));
-            }
-        }
-
-        public void writeSvmLiteVector(Writer writer){
-            try {
-                writer.write(this.label == NO_LABEL ? this.id : this.label + "");
-                this.vector.forEach((k, v) -> {
-                    try {
-                        writer.write(" " + k + ":" + v);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-                writer.write("\n");
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
-    public static void vectorize(List<File> inputs, File vectorFile, File dictionaryFile) throws IOException {
-        LOG.info("Vectorizing....");
-        Dictionary dictionary;
-        try (InputStream inputStream = new FileInputStream(dictionaryFile)){
-            LOG.info("Dictionary : {}", dictionaryFile);
-            dictionary = Dictionary.load(inputStream);
-        }
-        Map<String, Doc> clusters = new ConcurrentHashMap<>();
-        Map<String, Integer> clusterSize = new HashMap<>();
-
-        final AtomicLong counter = new AtomicLong();
-        final int nThreads = Constants.NUM_THREADS;
-        final long delay = 2000;
-        AtomicLong st = new AtomicLong(System.currentTimeMillis());
-        ThreadPoolExecutor pool = new ThreadPoolExecutor(nThreads, nThreads, 5, TimeUnit.MILLISECONDS,
-                new ArrayBlockingQueue<>(nThreads * 20));
-        getTextStream(inputs).forEach(line -> {
-            Runnable task = () -> {
-                counter.incrementAndGet();
-                JSONObject j = new JSONObject(line);
-                Doc d = new Doc(j.getString("cluster_id"), vectorizer.apply(Utils.getFeaturedText(j), dictionary),
-                        j.optInt("class", Doc.NO_LABEL));
-                if (clusters.containsKey(d.id)) {
-                    //clusters.get(d.id).merge(d);
-                    clusters.get(d.id).mergeMax(d);
-                } else {
-                    clusters.put(d.id, d);
-                }
-                clusterSize.put(d.id, 1 + clusterSize.getOrDefault(d.id, 0));
-            };
-
-            try {
-                pool.submit(task);
-            } catch (RejectedExecutionException e){
-                while (pool.getQueue().size() > 2 * nThreads) {
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e1) {
-                        e1.printStackTrace();
-                    }
-                }
-                pool.submit(task);
-            }
-            if (System.currentTimeMillis() - st.get() > delay){
-                st.set(System.currentTimeMillis());
-                LOG.info("Input = {}, Clusters={}, active threads={}, queued tasks={}", counter, clusters.size(),
-                        pool.getActiveCount(), pool.getQueue().size());
-            }
-        });
-
-        LOG.warn("Shutting down the pool");
-        try {
-            pool.awaitTermination(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        pool.shutdown();
-
-        //TODO: Normalize vector magnitudes to average on the cluster size
-        try (Writer writer = new FileWriter(vectorFile)) {
-            clusters.values().stream().forEach(d -> d.writeSvmLiteVector(writer));
-        }
-        LOG.info("Wrote {} vectors to {}", clusters.size(), vectorFile);
-    }
-
+    @Option(name = "-threads", usage = "Number of Threads"  )
+    public int threadCount = Constants.NUM_THREADS;
 
     /**
      * Predicts the class of vectors
@@ -304,13 +131,32 @@ public class SVMCli {
             NlpPipeline.GENERALIZE = true;
         }
 
+        if (Constants.NUM_THREADS != cli.threadCount){
+            System.out.println("Number of threads ::" + cli.threadCount);
+            Constants.NUM_THREADS = cli.threadCount;
+        }
+
+        ComputeBackend backend;
+        switch (cli.backend){
+            case Constants.SPARK:
+                System.out.println("Using spark backend");
+                backend = new SparkRunner();
+                break;
+            case Constants.THREADS:
+                System.out.println("Using spark multi threading backend");
+                backend = new ConcurrentRunner();
+                break;
+            default:
+                throw new IllegalArgumentException(cli.backend);
+        }
+
         for (String taskname: cli.tasknames) {
             switch (taskname){
                 case Constants.BUILD_DICT:
-                    buildDictionary(cli.inputFiles, cli.dictionaryFile);
+                    backend.makeDictionary(cli.inputFiles, cli.dictionaryFile);
                     break;
                 case Constants.VECTORIZE:
-                    vectorize(cli.inputFiles, cli.vector, cli.dictionaryFile);
+                    backend.vectorize(cli.inputFiles, cli.vector, cli.dictionaryFile);
                     break;
                 case Constants.PREDICT:
                     assert cli.modelFile.exists();
@@ -322,5 +168,6 @@ public class SVMCli {
                     throw new IllegalArgumentException(taskname + " is an unknown task");
             }
         }
+        backend.shutdown();
     }
 }

--- a/src/main/java/edu/usc/irds/ml/svm/SparkRunner.java
+++ b/src/main/java/edu/usc/irds/ml/svm/SparkRunner.java
@@ -1,0 +1,153 @@
+package edu.usc.irds.ml.svm;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.spark.api.java.function.PairFunction;
+import org.apache.spark.storage.StorageLevel;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import static edu.usc.irds.ml.svm.Dictionary.writeLines;
+
+
+/**
+ * This class uses spark to distribute (unlike {@link SVMCli} which uses threads)
+ *
+ */
+public class SparkRunner implements ComputeBackend {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SparkRunner.class);
+    private static final Set<String> REQ_KEYS = new HashSet<>(Arrays.asList("extracted_text", "doc_id", "class", "cluster_id"));
+
+    private interface IHolder {
+        NlpPipeline pipeline = new NlpPipeline();
+    }
+
+    private JavaSparkContext ctx;
+    private int nThreads = SVMCli.Constants.NUM_THREADS;
+
+    public SparkRunner() {
+        SparkConf conf = new SparkConf();
+        conf.setAppName("SVM job");
+        nThreads = SVMCli.Constants.NUM_THREADS;
+        conf.setMaster("local["+ nThreads +"]");
+        ctx = new JavaSparkContext(conf);
+    }
+
+
+    private static Function<String, JSONObject> DOC_PARSER = line -> {
+        JSONParser parser = new JSONParser();
+        JSONObject doc = (JSONObject) parser.parse(line);
+        //minify doc by removing unwanted stuff
+        Set keys = doc.keySet();
+        for (Object key : keys) {
+            if (!REQ_KEYS.contains(key)) {
+                doc.remove(key);
+            }
+        }
+        return doc;
+    };
+
+
+    public Dictionary makeDictionary(File input, File output) throws IOException {
+        JavaPairRDD<String, Long> rdd = ctx.textFile(input.getAbsolutePath())
+                .map(DOC_PARSER).map(doc -> doc.getOrDefault("extracted_text", "").toString())
+                .map(line -> IHolder.pipeline.getTokens(line, false))
+                .flatMapToPair((PairFlatMapFunction<Collection<String>, String, Long>) tokens ->
+                        tokens.stream().map(token -> new Tuple2<>(token, 1L)).iterator())
+                .reduceByKey((c1, c2) -> c1 + c2).persist(StorageLevel.MEMORY_AND_DISK());
+
+        //Java  API doesnt have sort by Value on RDD,
+        // So swapping key<->value, sort by key and swap back
+        JavaPairRDD<String, Long> sortedRdd = rdd.mapToPair(Tuple2::swap)
+                .sortByKey(false) //descending sort
+                .mapToPair(Tuple2::swap).cache();
+
+        List<String> lines = sortedRdd.keys().collect();
+        System.out.println("Saving output at " + output);
+        try (OutputStream stream = new FileOutputStream(output)){
+            writeLines(stream, lines);
+        }
+
+        String output2 = output.getAbsolutePath().replace(".txt", "") + ".tsv";
+        System.out.println("Saving Counts at " + output2);
+        lines = sortedRdd.map(tuple -> String.format("%s\t\t%d", tuple._1(), tuple._2())).collect();
+        try (OutputStream stream = new FileOutputStream(output2)){
+            writeLines(stream, lines);
+        }
+        return Dictionary.load(new FileInputStream(output));
+    }
+
+
+    public void vectorize(File input, File vectorFile, File dictionaryFile) throws IOException {
+
+        LOG.info("Vectorizing....");
+        Dictionary dictionary;
+        try (InputStream inputStream = new FileInputStream(dictionaryFile)){
+            LOG.info("Dictionary : {}", dictionaryFile);
+            dictionary = Dictionary.load(inputStream);
+        }
+
+        JavaRDD<JSONObject> rdd = ctx.textFile(input.getAbsolutePath()).map(DOC_PARSER);
+        JavaPairRDD<String, Doc> docRdd = rdd.mapToPair((PairFunction<JSONObject, String, Doc>) j -> {
+            String text = (String) j.get("extracted_text");
+            String clusterId = (String) j.get("cluster_id");
+            int label = ((Number) j.getOrDefault("class", Doc.NO_LABEL)).intValue(); // sometimes it could be long
+
+            Collection<String> tokens = IHolder.pipeline.getTokens(text, false);
+            TreeMap<Integer, Double> vector = new TreeMap<>();
+            tokens.forEach(token -> {
+                Integer number = dictionary.reverseLookup(token);
+                if (number != null) {
+                    vector.put(number, 1.0 + vector.getOrDefault(number, 0.0));
+                }
+            });
+            Doc d = new Doc(clusterId, vector, label);
+            return new Tuple2<>(d.id, d);
+        });
+
+        JavaPairRDD<String, Doc> clusterRdd = docRdd.reduceByKey((Function2<Doc, Doc, Doc>) (v1, v2) -> {
+            v1.mergeMax(v2);
+            v1.count.addAndGet(v1.count.get());
+            return v1;
+        }).sortByKey().cache(); // sorting to keep ids and data in same order
+
+        Map<String, Doc> clusters = clusterRdd.collectAsMap();
+        try (Writer writer = new FileWriter(vectorFile)) {
+            clusters.values().forEach(d -> d.writeSvmLiteVector(writer));
+        }
+        List<String> lines = clusterRdd.keys().collect();
+        try (OutputStream stream = new FileOutputStream(vectorFile.getAbsolutePath() + ".ids")){
+            writeLines(stream, lines);
+        }
+
+        LOG.info("Wrote {} vectors to {}", clusters.size(), vectorFile);
+    }
+
+    public void shutdown(){
+        ctx.stop();
+    }
+}


### PR DESCRIPTION
Created spark backend to support:
- map reduce to compute n-grams frequencies in dataset
- controlled parallelism using spark master
- Caching of results

The older java executor pool based backend can be used with a switch in cli args


